### PR TITLE
Move ring_bell from inetd to systemd socket activation.

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -10,6 +10,8 @@ etc/systemd/mqttpushd.service etc/systemd/system/
 etc/systemd/mqttsubd.service etc/systemd/system/
 etc/systemd/snmpgetd.service etc/systemd/system/
 etc/systemd/ro-setup.service etc/systemd/system/
+etc/systemd/ring_bell.service etc/systemd/system/
+etc/systemd/ring_bell.socket etc/systemd/system/
 sbin/* usr/sbin/
 munin/* usr/share/munin/plugins/
 lib/* usr/lib/dorfmap/

--- a/etc/inetd.conf
+++ b/etc/inetd.conf
@@ -35,5 +35,3 @@
 #:HAM-RADIO: amateur-radio services
 
 #:OTHER: Other services
-1337	stream  tcp nowait www-data /usr/sbin/ring_bell
-

--- a/etc/systemd/ring_bell.socket
+++ b/etc/systemd/ring_bell.socket
@@ -1,0 +1,10 @@
+[Unit]
+Description=Ring the bell
+After=network.target
+
+[Socket]
+ListenStream=1337
+Accept=true
+
+[Install]
+WantedBy=multi-user.target

--- a/etc/systemd/ring_bell@.service
+++ b/etc/systemd/ring_bell@.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Rings the bell
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/ring_bell
+StandardInput=socket
+StandardOutput=socket
+User=www-data


### PR DESCRIPTION
This PR replaces the inetd configuration file for ring_bell with two systemd units:
 * ring_bell.service: The service that is being started.
 * ring_bell.socket: The socket that is being allocated.

~~I haven't tested this, so please don't merge without proper testing.~~

The (now almost empty) inetd configuration file can probably be deleted.

Edit: I've tested the socket activation.